### PR TITLE
fix: WRDHYP was calculating the number of hypernymy paths for synsets

### DIFF
--- a/gispy/gist.py
+++ b/gispy/gist.py
@@ -400,7 +400,7 @@ class GIST:
 
                 hypernym_path_length = 0
                 for synset in synsets:
-                    hypernym_path_length += len(synset.hypernym_paths())
+                    hypernym_path_length += max(map(lambda path: len(path), synset.hypernym_paths()))
                 # computing the average length of hypernym path
                 hypernym_score = hypernym_path_length / len(synsets)
                 scores.append(hypernym_score)

--- a/gispy/gist.py
+++ b/gispy/gist.py
@@ -400,7 +400,7 @@ class GIST:
 
                 hypernym_path_length = 0
                 for synset in synsets:
-                    hypernym_path_length += max(map(lambda path: len(path), synset.hypernym_paths()))
+                    hypernym_path_length += statistics.mean(map(lambda path: len(path), synset.hypernym_paths()))
                 # computing the average length of hypernym path
                 hypernym_score = hypernym_path_length / len(synsets)
                 scores.append(hypernym_score)


### PR DESCRIPTION
In the paper, WRDHYP is described as a metric that computes "the average hypernym path length of all
synonym sets of a word". However, the implementation was instead using the length of synset.hypernym_paths(), which returns a list of different hypernym paths, therefore the implementation was using the number of hypernymy paths for synsets rather than their length. In this pull request I fixed it by taking the longest path a calculating its length, but you could also do an average or the shortest one.